### PR TITLE
Cleanup and StackSlab

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -68,7 +68,9 @@ rustflags = [
     "-Wclippy::useless_transmute",
     "-Wclippy::verbose_file_reads",
     "-Wclippy::zero_sized_map_values",
+    "-Wclippy::undocumented_unsafe_blocks",
     "-Wfuture_incompatible",
     "-Wnonstandard_style",
     "-Wrust_2018_idioms",
+    "-Wlet-underscore",
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Changed
+- [PR#16](https://github.com/Jake-Shadle/xdp/pull/16) changed `RxRing` and `TxRing` to use the new `slab::Slab` trait.
+- [PR#16](https://github.com/Jake-Shadle/xdp/pull/16) moved `HeapSlab` to the new `slab` module, and made it implement `slab::Slab`, changing it so that items are always pushed to the front and popped from the back, unlike the previous implementation which allowed both.
+
+### Added
+- [PR#16](https://github.com/Jake-Shadle/xdp/pull/16) added a new `slab::StackSlab<N>` fixed size ring buffer that implements `slab::Slab`.
+
+### Fixed
+- [PR#16](https://github.com/Jake-Shadle/xdp/pull/16) fixed some undefined behavior in the netlink code used to query NIC capabilities.
+- [PR#16](https://github.com/Jake-Shadle/xdp/pull/16) fixed a bug where TX metadata would not be added and would return an error if the packet headroom was not large enough for the metadata, this is irrelevant.
+
 ## [0.5.0] - 2025-02-27
 ### Changed
 - [PR#15](https://github.com/Jake-Shadle/xdp/pull/15) renamed `UdpPacket` -> `UdpHeaders`, and changed the contents to be the actual headers that can be de/serialized from/to the packet buffer.

--- a/crates/integ/tests/tx_checksum.rs
+++ b/crates/integ/tests/tx_checksum.rs
@@ -39,8 +39,8 @@ fn do_checksum_test(software: bool, vpair: &VethPair) {
             frame_size: FrameSize::TwoK,
             head_room: 20,
             frame_count: 64,
-            tx_metadata: software,
             software_checksum: software,
+            ..Default::default()
         }
         .build()
         .expect("invalid umem cfg"),
@@ -110,168 +110,148 @@ fn do_checksum_test(software: bool, vpair: &VethPair) {
         }};
     }
 
-    let res = std::thread::scope(|s| {
-        let client = s.spawn(|| -> Result<(), (&'static str, std::io::Error)> {
-            let dest: std::net::SocketAddr = (vpair.inside.ipv4, 7777).into();
-            let local = client_socket.local_addr().unwrap();
-            println!("sending {}b {local} -> {dest}", clientp.len());
-            client_socket
-                .send_to(clientp, dest)
-                .map_err(|err| ("failed to send first request", err))?;
+    std::thread::spawn(move || {
+        let timeout = PollTimeout::new(Some(std::time::Duration::from_millis(100)));
 
-            let mut response = [0u8; 20];
+        let mut slab = xdp::HeapSlab::with_capacity(BATCH_SIZE);
 
-            println!("receiving {}b {local} <- {dest}", serverp.len());
-            let (read, addr) = client_socket
-                .recv_from(&mut response)
-                .map_err(|err| ("failed to receive first response", err))?;
-            assert_eq!(&response[..read], serverp);
-            assert_eq!(addr, (vpair.inside.ipv4, sport).into());
+        unsafe {
+            poll_loop!({
+                xdp_socket.poll_read(timeout).unwrap();
+                if rx.recv(&umem, &mut slab) == 1 {
+                    break;
+                }
+            });
 
-            println!("sending {}b {local} -> {dest}", clientp.len());
-            client_socket
-                .send_to(clientp, dest)
-                .map_err(|err| ("failed to send second request", err))?;
+            let mut packet = slab.pop_back().unwrap();
+            let udp = nt::UdpHeaders::parse_packet(&packet)
+                .expect("failed to parse packet")
+                .expect("not a UDP packet");
 
-            println!("receiving {}b {local} <- {dest}", serverp.len());
-            let (read, addr) = client_socket
-                .recv_from(&mut response)
-                .map_err(|err| ("failed to receive second response", err))?;
+            // For this packet, we calculate the full checksum
+            packet.adjust_tail(-(udp.data_length as i32)).unwrap();
+            packet.insert(udp.data_offset, serverp).unwrap();
 
-            assert_eq!(&response[..read], serverp);
-            assert_eq!(addr, (vpair.inside.ipv4, sport).into());
+            let nt::IpHdr::V4(mut copy) = udp.ip else {
+                unreachable!()
+            };
+            std::mem::swap(&mut copy.destination, &mut copy.source);
+            copy.time_to_live -= 1;
 
-            Ok(())
-        });
+            let mut new = nt::UdpHeaders {
+                eth: nt::EthHdr {
+                    source: udp.eth.destination,
+                    destination: udp.eth.source,
+                    ether_type: udp.eth.ether_type,
+                },
+                ip: nt::IpHdr::V4(copy),
+                udp: nt::UdpHdr {
+                    destination: udp.udp.source,
+                    source: sport.into(),
+                    length: 0.into(),
+                    check: 0,
+                },
+                data_offset: udp.data_offset,
+                data_length: serverp.len(),
+            };
 
-        let server = s.spawn(|| {
-            let timeout = PollTimeout::new(Some(std::time::Duration::from_millis(100)));
+            // For this packet, we calculate the full checksum
+            let data_checksum = csum::partial(serverp, 0);
+            let full_checksum = new.calc_checksum(serverp.len(), data_checksum);
+            new.set_packet_headers(&mut packet, true).unwrap();
+            println!("Full checksum: {full_checksum:04x}");
 
-            let mut slab = xdp::HeapSlab::with_capacity(BATCH_SIZE);
+            slab.push_back(packet);
+            assert_eq!(tx.send(&mut slab), 1);
 
-            unsafe {
-                poll_loop!({
-                    xdp_socket.poll_read(timeout).unwrap();
-                    if rx.recv(&umem, &mut slab) == 1 {
-                        break;
-                    }
-                });
+            poll_loop!({
+                xdp_socket.poll(timeout).unwrap();
+                if cr.dequeue(&mut umem, 1) == 1 {
+                    break;
+                }
+            });
 
-                let mut packet = slab.pop_back().unwrap();
-                let udp = nt::UdpHeaders::parse_packet(&packet)
-                    .expect("failed to parse packet")
-                    .expect("not a UDP packet");
+            poll_loop!({
+                xdp_socket.poll_read(timeout).unwrap();
+                if rx.recv(&umem, &mut slab) == 1 {
+                    break;
+                }
+            });
 
-                // For this packet, we calculate the full checksum
-                packet.adjust_tail(-(udp.data_length as i32)).unwrap();
-                packet.insert(udp.data_offset, serverp).unwrap();
+            let mut packet = slab.pop_back().unwrap();
+            let udp = nt::UdpHeaders::parse_packet(&packet)
+                .expect("failed to parse packet")
+                .expect("not a UDP packet");
 
-                let nt::IpHdr::V4(mut copy) = udp.ip else {
-                    unreachable!()
-                };
-                std::mem::swap(&mut copy.destination, &mut copy.source);
-                copy.time_to_live -= 1;
+            packet.adjust_tail(-(udp.data_length as i32)).unwrap();
+            packet.insert(udp.data_offset, serverp).unwrap();
 
-                let mut new = nt::UdpHeaders {
-                    eth: nt::EthHdr {
-                        source: udp.eth.destination,
-                        destination: udp.eth.source,
-                        ether_type: udp.eth.ether_type,
-                    },
-                    ip: nt::IpHdr::V4(copy),
-                    udp: nt::UdpHdr {
-                        destination: udp.udp.source,
-                        source: sport.into(),
-                        length: 0.into(),
-                        check: 0,
-                    },
-                    data_offset: udp.data_offset,
-                    data_length: serverp.len(),
-                };
+            let nt::IpHdr::V4(mut copy) = udp.ip else {
+                unreachable!()
+            };
+            std::mem::swap(&mut copy.destination, &mut copy.source);
+            copy.time_to_live -= 1;
 
-                // For this packet, we calculate the full checksum
-                let data_checksum = csum::partial(serverp, 0);
-                let full_checksum = new.calc_checksum(serverp.len(), data_checksum);
-                new.set_packet_headers(&mut packet, true).unwrap();
-                println!("Full checksum: {full_checksum:04x}");
+            let mut new = nt::UdpHeaders {
+                eth: nt::EthHdr {
+                    source: udp.eth.destination,
+                    destination: udp.eth.source,
+                    ether_type: udp.eth.ether_type,
+                },
+                ip: nt::IpHdr::V4(copy),
+                udp: nt::UdpHdr {
+                    destination: udp.udp.source,
+                    source: sport.into(),
+                    length: 0.into(),
+                    check: 0,
+                },
+                data_offset: udp.data_offset,
+                data_length: serverp.len(),
+            };
+            new.set_packet_headers(&mut packet, true).unwrap();
+            println!(
+                "partial checksum: {:04x}",
+                packet.calc_udp_checksum().unwrap()
+            );
 
-                slab.push_back(packet);
-                assert_eq!(tx.send(&mut slab), 1);
+            slab.push_back(packet);
+            assert_eq!(tx.send(&mut slab), 1);
 
-                poll_loop!({
-                    xdp_socket.poll(timeout).unwrap();
-                    if cr.dequeue(&mut umem, 1) == 1 {
-                        break;
-                    }
-                });
-
-                poll_loop!({
-                    xdp_socket.poll_read(timeout).unwrap();
-                    if rx.recv(&umem, &mut slab) == 1 {
-                        break;
-                    }
-                });
-
-                let mut packet = slab.pop_back().unwrap();
-                let udp = nt::UdpHeaders::parse_packet(&packet)
-                    .expect("failed to parse packet")
-                    .expect("not a UDP packet");
-
-                packet.adjust_tail(-(udp.data_length as i32)).unwrap();
-                packet.insert(udp.data_offset, serverp).unwrap();
-
-                let nt::IpHdr::V4(mut copy) = udp.ip else {
-                    unreachable!()
-                };
-                std::mem::swap(&mut copy.destination, &mut copy.source);
-                copy.time_to_live -= 1;
-
-                let mut new = nt::UdpHeaders {
-                    eth: nt::EthHdr {
-                        source: udp.eth.destination,
-                        destination: udp.eth.source,
-                        ether_type: udp.eth.ether_type,
-                    },
-                    ip: nt::IpHdr::V4(copy),
-                    udp: nt::UdpHdr {
-                        destination: udp.udp.source,
-                        source: sport.into(),
-                        length: 0.into(),
-                        check: 0,
-                    },
-                    data_offset: udp.data_offset,
-                    data_length: serverp.len(),
-                };
-                new.set_packet_headers(&mut packet, true).unwrap();
-                println!(
-                    "partial checksum: {:04x}",
-                    packet.calc_udp_checksum().unwrap()
-                );
-
-                slab.push_back(packet);
-                assert_eq!(tx.send(&mut slab), 1);
-
-                poll_loop!({
-                    xdp_socket.poll(timeout).unwrap();
-                    if cr.dequeue(&mut umem, 1) == 1 {
-                        break;
-                    }
-                });
-            }
-        });
-
-        let err = if let Err(err) = client.join().unwrap() {
-            run.store(false, std::sync::atomic::Ordering::Relaxed);
-            Some(err)
-        } else {
-            None
-        };
-
-        server.join().unwrap();
-        err
+            poll_loop!({
+                xdp_socket.poll(timeout).unwrap();
+                if cr.dequeue(&mut umem, 1) == 1 {
+                    break;
+                }
+            });
+        }
     });
 
-    if let Some((msg, err)) = res {
-        panic!("{msg}: {err}");
-    }
+    let dest: std::net::SocketAddr = (vpair.inside.ipv4, 7777).into();
+    let local = client_socket.local_addr().unwrap();
+    println!("sending {}b {local} -> {dest}", clientp.len());
+    client_socket
+        .send_to(clientp, dest)
+        .expect("failed to send first request");
+
+    let mut response = [0u8; 20];
+
+    println!("receiving {}b {local} <- {dest}", serverp.len());
+    let (read, addr) = client_socket
+        .recv_from(&mut response)
+        .expect("failed to receive first response");
+    assert_eq!(&response[..read], serverp);
+    assert_eq!(addr, (vpair.inside.ipv4, sport).into());
+
+    println!("sending {}b {local} -> {dest}", clientp.len());
+    client_socket
+        .send_to(clientp, dest)
+        .expect("failed to send second request");
+
+    println!("receiving {}b {local} <- {dest}", serverp.len());
+    let (read, addr) = client_socket
+        .recv_from(&mut response)
+        .expect("failed to receive second response");
+
+    assert_eq!(&response[..read], serverp);
+    assert_eq!(addr, (vpair.inside.ipv4, sport).into());
 }

--- a/crates/tests/tests/slab.rs
+++ b/crates/tests/tests/slab.rs
@@ -1,0 +1,90 @@
+use xdp::slab::Slab as _;
+
+xdp::slab!(TestSlab, u8);
+
+fn umem(frame_count: u32, head_room: u32) -> xdp::Umem {
+    use xdp::umem;
+
+    umem::Umem::map(
+        umem::UmemCfgBuilder {
+            frame_size: umem::FrameSize::TwoK,
+            head_room,
+            frame_count,
+            ..Default::default()
+        }
+        .build()
+        .unwrap(),
+    )
+    .unwrap()
+}
+
+#[test]
+fn edge_conditions() {
+    const CAP: usize = 64;
+
+    let mut ss = TestSlab::<CAP>::new();
+    let mut umem = umem(80, 0);
+
+    assert!(ss.is_empty());
+    assert_eq!(ss.available(), CAP);
+    assert_eq!(ss.len(), 0);
+
+    for _ in 0..CAP {
+        let packet = unsafe { umem.alloc() }.unwrap();
+        ss.push_front(packet);
+    }
+
+    assert!(!ss.is_empty());
+    assert_eq!(ss.available(), 0);
+    assert_eq!(ss.len(), CAP);
+
+    let over = unsafe { umem.alloc() }.unwrap();
+    let over = ss.push_front(over).unwrap();
+
+    let back = ss.pop_back().unwrap();
+    assert_eq!(ss.available(), 1);
+    assert_eq!(ss.len(), CAP - 1);
+    assert!(ss.push_front(over).is_none());
+
+    umem.free_packet(back);
+
+    while let Some(p) = ss.pop_back() {
+        umem.free_packet(p);
+    }
+
+    assert!(ss.is_empty());
+    assert_eq!(ss.available(), CAP);
+    assert_eq!(ss.len(), 0);
+
+    for i in 0..CAP {
+        let mut packet = unsafe { umem.alloc() }.unwrap();
+        packet.insert(0, &[i as u8]).unwrap();
+        ss.push_front(packet);
+    }
+
+    assert!(!ss.is_empty());
+    assert_eq!(ss.available(), 0);
+    assert_eq!(ss.len(), CAP);
+
+    for _ in 0..9 {
+        for _ in 0..CAP {
+            let p = ss.pop_back().unwrap();
+            assert_eq!(ss.len(), CAP - 1);
+            assert!(ss.push_front(p).is_none());
+        }
+    }
+
+    assert_eq!(ss.len(), CAP);
+
+    for i in 0..CAP {
+        let p = ss.pop_back().unwrap();
+        assert_eq!(&p[0..1], &[i as u8]);
+        if i % 2 == 1 {
+            assert!(ss.push_front(p).is_none());
+        } else {
+            umem.free_packet(p);
+        }
+    }
+
+    assert_eq!(ss.len(), CAP >> 1);
+}

--- a/src/affinity.rs
+++ b/src/affinity.rs
@@ -13,6 +13,7 @@ impl CoreId {
     /// Sets the core affinity for the current thread
     #[inline]
     pub fn set_affinity(self) -> Result<()> {
+        // SAFETY: syscall
         unsafe {
             let mut set = mem::zeroed();
 
@@ -63,6 +64,7 @@ impl CoreIds {
     /// Creates an iterator over the available CPUs
     #[inline]
     pub fn new() -> Result<Self> {
+        // SAFETY: syscall
         let set = unsafe {
             let mut set = mem::zeroed();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod libc;
 mod mmap;
 pub mod nic;
 mod rings;
+pub mod slab;
 pub mod socket;
 pub mod umem;
 
@@ -38,76 +39,3 @@ pub use rings::{
     CompletionRing, FillRing, RingConfig, RingConfigBuilder, Rings, RxRing, TxRing,
     WakableFillRing, WakableRings, WakableTxRing,
 };
-
-// TODO: This is using VecDequeue (heap) internally, but in most situations this
-// could just be fixed sizes with a const N: usize and stored on the stack, so
-// might be worth doing that implementation inline, just not super important
-/// A ring buffer used to do bulk pops from a [`RxRing`] or pushes to a [`TxRing`]
-///
-/// This is allocated on the heap, but will _not_ grow, and is intended to be
-/// allocated once before entering an I/O loop
-pub struct HeapSlab {
-    vd: std::collections::VecDeque<Packet>,
-}
-
-impl HeapSlab {
-    /// Allocates a new [`Self`] with the maximum specified capacity
-    #[inline]
-    pub fn with_capacity(capacity: usize) -> Self {
-        Self {
-            vd: std::collections::VecDeque::with_capacity(capacity),
-        }
-    }
-
-    /// The number of packets in the slab
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.vd.len()
-    }
-
-    /// True if the slab is empty
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.vd.is_empty()
-    }
-
-    /// The number of packets that can be pushed to the slab
-    #[inline]
-    pub fn available(&self) -> usize {
-        self.vd.capacity() - self.vd.len()
-    }
-
-    /// Pops the front packet if any
-    #[inline]
-    pub fn pop_front(&mut self) -> Option<Packet> {
-        self.vd.pop_front()
-    }
-
-    /// Pops the back packet if any
-    #[inline]
-    pub fn pop_back(&mut self) -> Option<Packet> {
-        self.vd.pop_back()
-    }
-
-    /// Pushes a packet to the front, returning `Some` if the slab is at capacity
-    #[inline]
-    pub fn push_front(&mut self, item: Packet) -> Option<Packet> {
-        if self.available() > 0 {
-            self.vd.push_front(item);
-            None
-        } else {
-            Some(item)
-        }
-    }
-
-    /// Pushes a packet to the back, returning `Some` if the slab is at capacity
-    #[inline]
-    pub fn push_back(&mut self, item: Packet) -> Option<Packet> {
-        if self.available() > 0 {
-            self.vd.push_back(item);
-            None
-        } else {
-            Some(item)
-        }
-    }
-}

--- a/src/libc.rs
+++ b/src/libc.rs
@@ -229,6 +229,7 @@ pub mod xdp {
         pub offload: xsk_tx_offload,
     }
 
+    // SAFETY: POD
     unsafe impl crate::packet::Pod for xsk_tx_metadata {}
 
     /// Flags available when registering a [`crate::Umem`] with a socket

--- a/src/libc.rs
+++ b/src/libc.rs
@@ -17,17 +17,17 @@ use std::{ffi::c_void, os::fd::RawFd};
 
 /// Internal flags to enable TX offload features if they were enabled at
 /// socket creation
-#[derive(Copy, Clone)]
-#[repr(u32)]
-pub enum InternalXdpFlags {
-    /// TX checksum offload is enabled
-    SupportsChecksumOffload = 1 << 31,
-    /// TX checksum offload is enabled in software
-    SoftwareOffload = (1 << 30) | (1 << 31),
+pub(crate) mod InternalXdpFlags {
+    pub type Enum = u32;
+
+    /// TX checksum offload is supported
+    pub const SUPPORTS_CHECKSUM_OFFLOAD: Enum = 1 << 31;
+    /// TX checksum offload is done in software rather than hardware
+    pub const USE_SOFTWARE_OFFLOAD: Enum = SUPPORTS_CHECKSUM_OFFLOAD | (1 << 30);
     /// TX completion timestamp is supported
-    CompletionTimestamp = 1 << 29,
+    pub const SUPPORTS_TIMESTAMP: Enum = 1 << 29;
     /// Mask of valid flags
-    Mask = 0xf0000000,
+    pub const MASK: Enum = 0xf0000000;
 }
 
 /// The bindings specific to the various rings used by `AF_XDP` sockets.

--- a/src/libc.rs
+++ b/src/libc.rs
@@ -446,7 +446,7 @@ pub(crate) mod iface {
     #[repr(C)]
     pub struct ifaddrs {
         pub ifa_next: *mut ifaddrs,
-        pub ifa_name: *mut c_char,
+        pub ifa_name: *mut u8,
         pub ifa_flags: u32,
         pub ifa_addr: *mut sockaddr,
         pub ifa_netmask: *mut sockaddr,
@@ -460,7 +460,7 @@ pub(crate) mod iface {
         pub d_off: i64,
         pub d_reclen: u16,
         pub d_type: u8,
-        pub d_name: [c_char; 256],
+        pub d_name: [u8; 256],
     }
 
     #[repr(C)]
@@ -470,7 +470,7 @@ pub(crate) mod iface {
 
     #[repr(C)]
     pub struct ifreq {
-        pub ifr_name: [c_char; 16],
+        pub ifr_name: [u8; 16],
         pub ifr_ifru: ifr_ifru,
     }
 
@@ -484,21 +484,21 @@ pub(crate) mod iface {
         pub fn freeifaddrs(ifap: *mut ifaddrs) -> i32;
 
         /// <https://man7.org/linux/man-pages/man3/if_nametoindex.3.html>
-        pub fn if_indextoname(ifindex: u32, ifname: *mut c_char) -> *mut c_char;
+        pub fn if_indextoname(ifindex: u32, ifname: *mut u8) -> *mut u8;
         /// <https://man7.org/linux/man-pages/man3/if_nametoindex.3.html>
-        pub fn if_nametoindex(ifname: *const c_char) -> u32;
+        pub fn if_nametoindex(ifname: *const u8) -> u32;
 
         /// <https://man7.org/linux/man-pages/man2/ioctl.2.html>
         pub fn ioctl(fd: RawFd, request: u64, ...) -> i32;
 
         /// <https://man7.org/linux/man-pages/man3/opendir.3.html>
-        pub fn opendir(dirname: *const c_char) -> *mut DIR;
+        pub fn opendir(dirname: *const u8) -> *mut DIR;
         /// <https://man7.org/linux/man-pages/man3/closedir.3.html>
         pub fn closedir(dirp: *mut DIR) -> i32;
         /// <https://man7.org/linux/man-pages/man3/readdir.3.html>
         pub fn readdir(dirp: *mut DIR) -> *mut dirent;
 
-        pub fn strncmp(cs: *const c_char, ct: *const c_char, n: usize) -> i32;
+        pub fn strncmp(cs: *const u8, ct: *const u8, n: usize) -> i32;
     }
 }
 

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -84,7 +84,7 @@ impl Mmap {
     }
 }
 
-//unsafe impl Sync for Mmap {}
+// SAFETY: Safe to send across threads
 unsafe impl Send for Mmap {}
 
 impl Drop for Mmap {

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -18,7 +18,7 @@ fn page_size() -> usize {
 }
 
 pub struct Mmap {
-    addr: *mut std::ffi::c_void,
+    pub(crate) ptr: *mut u8,
     len: usize,
 }
 
@@ -54,6 +54,7 @@ impl Mmap {
         flags: mmap::Flags::Enum,
         file: i32,
     ) -> std::io::Result<Self> {
+        // SAFETY: syscalls
         unsafe {
             let alignment = offset % page_size() as u64;
             let aligned_offset = offset - alignment;
@@ -70,33 +71,25 @@ impl Mmap {
                 Err(std::io::Error::last_os_error())
             } else {
                 Ok(Self {
-                    addr: base.add(alignment as _),
+                    ptr: base.add(alignment as _).cast(),
                     len: length,
                 })
             }
         }
     }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
 }
 
-unsafe impl Sync for Mmap {}
+//unsafe impl Sync for Mmap {}
 unsafe impl Send for Mmap {}
-
-impl std::ops::Deref for Mmap {
-    type Target = [u8];
-
-    fn deref(&self) -> &Self::Target {
-        unsafe { std::slice::from_raw_parts(self.addr.cast(), self.len) }
-    }
-}
-
-impl std::ops::DerefMut for Mmap {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe { std::slice::from_raw_parts_mut(self.addr.cast(), self.len) }
-    }
-}
 
 impl Drop for Mmap {
     fn drop(&mut self) {
-        unsafe { mmap::munmap(self.addr, self.len) };
+        // SAFETY: syscall, the pointer is validated before we create an Mmap
+        unsafe { mmap::munmap(self.ptr.cast(), self.len) };
     }
 }

--- a/src/nic.rs
+++ b/src/nic.rs
@@ -301,19 +301,19 @@ impl NicIndex {
     /// `None` if the interface cannot be found
     #[inline]
     pub fn lookup_by_name(ifname: &std::ffi::CStr) -> std::io::Result<Option<Self>> {
-        unsafe {
-            let res = iface::if_nametoindex(ifname.as_ptr());
-            if res == 0 {
-                let err = std::io::Error::last_os_error();
+        // SAFETY: syscall, we give it a valid pointer
+        let res = unsafe { iface::if_nametoindex(ifname.as_ptr().cast()) };
 
-                if err.raw_os_error() == Some(iface::ENODEV) {
-                    Ok(None)
-                } else {
-                    Err(err)
-                }
+        if res == 0 {
+            let err = std::io::Error::last_os_error();
+
+            if err.raw_os_error() == Some(iface::ENODEV) {
+                Ok(None)
             } else {
-                Ok(Some(Self(res)))
+                Err(err)
             }
+        } else {
+            Ok(Some(Self(res)))
         }
     }
 
@@ -321,6 +321,7 @@ impl NicIndex {
     #[inline]
     pub fn name(&self) -> std::io::Result<NicName> {
         let mut name = [0; iface::IF_NAMESIZE];
+        // SAFETY: syscall, we give it a valid pointer
         if unsafe { !iface::if_indextoname(self.0, name.as_mut_ptr()).is_null() } {
             let len = name
                 .iter()
@@ -337,6 +338,7 @@ impl NicIndex {
     pub fn addresses(
         &self,
     ) -> std::io::Result<(Option<std::net::Ipv4Addr>, Option<std::net::Ipv6Addr>)> {
+        // SAFETY: syscalls
         unsafe {
             let mut ifaddrs = std::mem::MaybeUninit::<*mut iface::ifaddrs>::uninit();
             if iface::getifaddrs(ifaddrs.as_mut_ptr()) != 0 {
@@ -349,6 +351,7 @@ impl NicIndex {
             struct Ifaddrs(*mut iface::ifaddrs);
             impl Drop for Ifaddrs {
                 fn drop(&mut self) {
+                    // SAFETY: syscall, we validate the pointer before allowing it to be freed
                     unsafe { iface::freeifaddrs(self.0) };
                 }
             }
@@ -676,9 +679,10 @@ impl Iterator for InterfaceIter {
             ifname[..name.len()].copy_from_slice(name.as_bytes());
             ifname[name.len()] = 0;
 
-            let Ok(Some(iface)) = NicIndex::lookup_by_name(unsafe {
-                std::ffi::CStr::from_bytes_with_nul_unchecked(&ifname)
-            }) else {
+            let Ok(Some(iface)) = NicIndex::lookup_by_name(
+                // SAFETY: we ensure there is a null byte at the end
+                unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(&ifname) },
+            ) else {
                 continue;
             };
 

--- a/src/nic.rs
+++ b/src/nic.rs
@@ -509,10 +509,10 @@ impl NicIndex {
                         continue;
                     }
 
-                    if entry.d_name[..2] == [b'r' as i8, b'x' as i8] {
+                    if entry.d_name[..2] == [b'r', b'x'] {
                         channels.max_rx += 1;
                         channels.rx_count += 1;
-                    } else if entry.d_name[..2] == [b't' as i8, b'x' as i8] {
+                    } else if entry.d_name[..2] == [b't', b'x'] {
                         channels.max_tx += 1;
                         channels.tx_count += 1;
                     }
@@ -587,7 +587,7 @@ impl PartialEq<NicIndex> for NicIndex {
 /// The human-readable name assigned to a network device
 #[derive(Copy, Clone)]
 pub struct NicName {
-    arr: [i8; iface::IF_NAMESIZE],
+    arr: [u8; iface::IF_NAMESIZE],
     len: usize,
 }
 
@@ -596,10 +596,7 @@ impl NicName {
     /// unlikely case the interface name is not utf-8
     #[inline]
     pub fn as_str(&self) -> Option<&str> {
-        std::str::from_utf8(unsafe {
-            std::slice::from_raw_parts(self.arr.as_ptr().cast(), self.len)
-        })
-        .ok()
+        std::str::from_utf8(&self.arr[..self.len]).ok()
     }
 }
 

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -416,8 +416,8 @@ impl Packet {
 
     /// Sets the specified [TX metadata](https://github.com/torvalds/linux/blob/ae90f6a6170d7a7a1aa4fddf664fbd093e3023bc/Documentation/networking/xsk-tx-metadata.rst)
     ///
-    /// Calling this function requires that the [`crate::umem::UmemCfgBuilder::tx_metadata`]
-    /// was true.
+    /// Calling this function requires that the [`crate::umem::UmemCfgBuilder::tx_checksum`]
+    /// and/or [`crate::umem::UmemCfgBuilder::tx_timestamp`] were true
     ///
     /// - If `csum` is `CsumOffload::Request`, this will request that the Layer 4
     ///     checksum computation be offload to the NIC before transmission. Note that

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -477,6 +477,19 @@ impl Packet {
 
         Ok(())
     }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn inner_copy(&mut self) -> Self {
+        Self {
+            data: self.data,
+            capacity: self.capacity,
+            head: self.head,
+            tail: self.tail,
+            base: self.base,
+            options: self.options,
+        }
+    }
 }
 
 impl std::ops::Deref for Packet {

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -447,7 +447,6 @@ impl Packet {
 
             std::ptr::write_unaligned(
                 self.data
-                    .as_mut_ptr()
                     .byte_offset((self.head - std::mem::size_of::<xdp::xsk_tx_metadata>()) as _)
                     .cast(),
                 tx_meta,

--- a/src/packet/net_types.rs
+++ b/src/packet/net_types.rs
@@ -10,6 +10,7 @@ use std::{
 
 macro_rules! len {
     ($record:ty) => {
+        // SAFETY: We only use this macro on types it is safe for
         unsafe impl Pod for $record {}
 
         impl $record {

--- a/src/rings.rs
+++ b/src/rings.rs
@@ -177,7 +177,7 @@ fn map_ring<T>(
     offset: libc::RingPageOffsets,
     offsets: &libc::xdp_ring_offset,
 ) -> std::io::Result<(crate::mmap::Mmap, XskRing<T>)> {
-    let mut mmap = crate::mmap::Mmap::map_ring(
+    let mmap = crate::mmap::Mmap::map_ring(
         offsets.desc as usize + (count as usize * std::mem::size_of::<T>()),
         offset as u64,
         socket,
@@ -185,7 +185,7 @@ fn map_ring<T>(
 
     // SAFETY: The lifetime of the pointers are the same as the mmap
     let ring = unsafe {
-        let map = mmap.as_mut_ptr();
+        let map = mmap.ptr;
 
         let producer = AtomicU32::from_ptr(map.byte_offset(offsets.producer as _).cast());
         let consumer = AtomicU32::from_ptr(map.byte_offset(offsets.consumer as _).cast());

--- a/src/rings.rs
+++ b/src/rings.rs
@@ -260,6 +260,7 @@ impl<T> std::ops::Index<usize> for XskProducer<T> {
 
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
+        // SAFETY: each ring impl ensures the index is valid
         unsafe { self.0.ring.get_unchecked(index) }
     }
 }
@@ -267,6 +268,7 @@ impl<T> std::ops::Index<usize> for XskProducer<T> {
 impl<T> std::ops::IndexMut<usize> for XskProducer<T> {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        // SAFETY: each ring impl ensures the index is valid
         unsafe { self.0.ring.get_unchecked_mut(index) }
     }
 }

--- a/src/rings/fill.rs
+++ b/src/rings/fill.rs
@@ -104,6 +104,7 @@ impl WakableFillRing {
         num_packets: usize,
         wakeup: bool,
     ) -> std::io::Result<usize> {
+        // SAFETY: FillRing::enqueue is unsafe
         let queued = unsafe { self.inner.enqueue(umem, num_packets) };
 
         if queued > 0 && wakeup {

--- a/src/rings/fill.rs
+++ b/src/rings/fill.rs
@@ -51,8 +51,8 @@ impl FillRing {
     /// lower than the requested `num_packets` if the [`Umem`] didn't have enough
     /// open slots, or the rx ring had insufficient capacity
     pub unsafe fn enqueue(&mut self, umem: &mut Umem, num_packets: usize) -> usize {
-        let mut popper = umem.popper();
-        let requested = std::cmp::min(popper.len(), num_packets);
+        let available = umem.available();
+        let requested = std::cmp::min(available.len(), num_packets);
         if requested == 0 {
             return 0;
         }
@@ -62,7 +62,7 @@ impl FillRing {
         if actual > 0 {
             let mask = self.ring.mask();
             for i in idx..idx + actual {
-                self.ring[i & mask] = popper.pop();
+                self.ring[i & mask] = available.pop_front().unwrap();
             }
 
             self.ring.submit(actual as _);

--- a/src/rings/tx.rs
+++ b/src/rings/tx.rs
@@ -2,8 +2,8 @@
 //! sent by the NIC the ring is bound to
 
 use crate::{
-    HeapSlab,
     libc::{self, rings},
+    slab::Slab,
 };
 
 /// The ring used to enqueue packets for the kernel to send
@@ -56,7 +56,7 @@ impl TxRing {
     /// The number of packets that were actually enqueued. This number can be
     /// lower than the requested `num_packets` if the ring doesn't have sufficient
     /// capacity
-    pub unsafe fn send(&mut self, packets: &mut HeapSlab) -> usize {
+    pub unsafe fn send<S: Slab>(&mut self, packets: &mut S) -> usize {
         let requested = packets.len();
         if requested == 0 {
             return 0;
@@ -67,7 +67,7 @@ impl TxRing {
         if actual > 0 {
             let mask = self.ring.mask();
             for i in idx..idx + actual {
-                let Some(packet) = packets.pop_front() else {
+                let Some(packet) = packets.pop_back() else {
                     unreachable!()
                 };
 
@@ -109,7 +109,11 @@ impl WakableTxRing {
     /// The number of packets that were actually enqueued. This number can be
     /// lower than the requested `num_packets` if the ring doesn't have sufficient
     /// capacity
-    pub unsafe fn send(&mut self, packets: &mut HeapSlab, wakeup: bool) -> std::io::Result<usize> {
+    pub unsafe fn send<S: Slab>(
+        &mut self,
+        packets: &mut S,
+        wakeup: bool,
+    ) -> std::io::Result<usize> {
         // SAFETY: TxRing::send is unsafe
         let queued = unsafe { self.inner.send(packets) };
 

--- a/src/rings/tx.rs
+++ b/src/rings/tx.rs
@@ -110,6 +110,7 @@ impl WakableTxRing {
     /// lower than the requested `num_packets` if the ring doesn't have sufficient
     /// capacity
     pub unsafe fn send(&mut self, packets: &mut HeapSlab, wakeup: bool) -> std::io::Result<usize> {
+        // SAFETY: TxRing::send is unsafe
         let queued = unsafe { self.inner.send(packets) };
 
         if queued > 0 && wakeup {

--- a/src/slab.rs
+++ b/src/slab.rs
@@ -1,0 +1,162 @@
+//! Contains simple slab data structures for use with the TX and RX rings
+
+use crate::Packet;
+
+/// A fixed size buffer of packets
+pub trait Slab {
+    /// The number of free slots available
+    fn available(&self) -> usize;
+    /// The number of occupied slots
+    fn len(&self) -> usize;
+    /// True if the slab is empty
+    fn is_empty(&self) -> bool;
+    /// Pushes a packet to the slab, returning the packet if the slab is at capacity
+    fn push_front(&mut self, packet: Packet) -> Option<Packet>;
+    /// Pops the back packet if any
+    fn pop_back(&mut self) -> Option<Packet>;
+}
+
+// A heap allocated slab, using [`std::collections::VecDequeue`]
+///
+/// This is allocated on the heap, but will _not_ grow, and is intended to be
+/// allocated once before entering an I/O loop
+pub struct HeapSlab {
+    vd: std::collections::VecDeque<Packet>,
+}
+
+impl HeapSlab {
+    /// Allocates a new [`Self`] with the maximum specified capacity
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            vd: std::collections::VecDeque::with_capacity(capacity),
+        }
+    }
+}
+
+impl Slab for HeapSlab {
+    /// The number of packets in the slab
+    #[inline]
+    fn len(&self) -> usize {
+        self.vd.len()
+    }
+
+    /// True if the slab is empty
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.vd.is_empty()
+    }
+
+    /// The number of packets that can be pushed to the slab
+    #[inline]
+    fn available(&self) -> usize {
+        self.vd.capacity() - self.vd.len()
+    }
+
+    /// Pops the front packet if any
+    #[inline]
+    fn pop_back(&mut self) -> Option<Packet> {
+        self.vd.pop_back()
+    }
+
+    /// Pushes a packet to the front, returning `Some` if the slab is at capacity
+    #[inline]
+    fn push_front(&mut self, item: Packet) -> Option<Packet> {
+        if self.available() > 0 {
+            self.vd.push_front(item);
+            None
+        } else {
+            Some(item)
+        }
+    }
+}
+
+struct AssertPowerOf2<const N: usize>;
+
+impl<const N: usize> AssertPowerOf2<N> {
+    const OK: () = assert!(usize::is_power_of_two(N), "must be a power of 2");
+}
+
+#[doc(hidden)]
+pub const fn assert_power_of_2<const N: usize>() {
+    let () = AssertPowerOf2::<N>::OK;
+}
+
+/// Slab impl macro, only public for creating testing slabs with integer types < usize
+#[cfg_attr(debug_assertions, macro_export)]
+macro_rules! slab {
+    ($name:ident, $int:ty) => {
+        /// A stack allocated, fixed size, ring buffer
+        pub struct $name<const N: usize> {
+            ring: [$crate::Packet; N],
+            read: $int,
+            write: $int,
+        }
+
+        impl<const N: usize> $name<N> {
+            /// Creates a new slab, `N` must be a power of 2
+            #[allow(clippy::new_without_default)]
+            pub fn new() -> Self {
+                $crate::slab::assert_power_of_2::<N>();
+
+                Self {
+                    // SAFETY: Packet is just a POD
+                    ring: unsafe { std::mem::zeroed() },
+                    read: 0,
+                    write: 0,
+                }
+            }
+        }
+
+        impl<const N: usize> $crate::slab::Slab for $name<N> {
+            /// The current number of packets in the slab
+            #[inline]
+            fn len(&self) -> usize {
+                if self.write >= self.read {
+                    (self.write - self.read) as _
+                } else {
+                    <$int>::MAX as usize - self.read as usize + self.write as usize + 1
+                }
+            }
+
+            /// True if the slab is empty
+            #[inline]
+            fn is_empty(&self) -> bool {
+                self.write == self.read
+            }
+
+            /// The number of packets that can be pushed to the slab
+            #[inline]
+            fn available(&self) -> usize {
+                N - self.len()
+            }
+
+            /// Pops the back packet if any
+            #[inline]
+            fn pop_back(&mut self) -> Option<$crate::Packet> {
+                if self.is_empty() {
+                    return None;
+                }
+
+                let index = self.read as usize % N;
+                self.read = self.read.wrapping_add(1);
+                Some(self.ring[index].inner_copy())
+            }
+
+            /// Pushes a packet to the front, returning `Some` if the slab is at capacity
+            #[inline]
+            fn push_front(&mut self, item: $crate::Packet) -> Option<$crate::Packet> {
+                if self.available() > 0 {
+                    let index = self.write as usize % N;
+                    self.write = self.write.wrapping_add(1);
+                    self.ring[index] = item;
+                    None
+                } else {
+                    Some(item)
+                }
+            }
+        }
+    };
+}
+
+slab!(StackSlab, usize);

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -231,12 +231,12 @@ impl XdpSocketBuilder {
             flags |= xdp::UmemFlags::XDP_UMEM_UNALIGNED_CHUNK_FLAG;
         }
 
-        if umem.options & InternalXdpFlags::SupportsChecksumOffload as u32 != 0 {
+        if umem.options != 0 {
             // This value is only available in very recent ~6.11 kernels and was introduced
             // for those who didn't zero initialize xdp_umem_reg
             flags |= xdp::UmemFlags::XDP_UMEM_TX_METADATA_LEN;
 
-            if umem.options & InternalXdpFlags::SoftwareOffload as u32 != 0 {
+            if umem.options & InternalXdpFlags::USE_SOFTWARE_OFFLOAD != 0 {
                 flags |= xdp::UmemFlags::XDP_UMEM_TX_SW_CSUM;
             }
         }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -320,6 +320,7 @@ impl XdpSocketBuilder {
             sxdp_shared_umem_fd: 0,
         };
 
+        // SAFETY: syscall, all inputs are valid
         if unsafe {
             socket::bind(
                 self.sock.as_raw_fd(),
@@ -336,15 +337,7 @@ impl XdpSocketBuilder {
 
     #[inline]
     fn set_sockopt<T>(&mut self, name: OptName, val: &T) -> Result<(), SocketError> {
-        // let level = if matches!(
-        //     name,
-        //     OptName::PreferBusyPoll | OptName::BusyPoll | OptName::BusyPollBudget
-        // ) {
-        //     libc::SOL_SOCKET
-        // } else {
-        //     libc::SOL_XDP
-        // };
-
+        // SAFETY: syscall, all inputs are valid
         if unsafe {
             libc::socket::setsockopt(
                 self.sock.as_raw_fd(),
@@ -424,6 +417,7 @@ impl XdpSocket {
 
     #[inline]
     fn poll_inner(&self, events: i16, timeout: PollTimeout) -> std::io::Result<bool> {
+        // SAFETY: syscall, all inputs are valid
         let ret = unsafe {
             socket::poll(
                 &mut socket::pollfd {

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -238,7 +238,7 @@ impl XdpSocketBuilder {
         }
 
         let umem_reg = xdp::XdpUmemReg {
-            addr: umem.mmap.as_ptr() as _,
+            addr: umem.mmap.ptr as _,
             len: umem.mmap.len() as _,
             chunk_size: umem.frame_size as _,
             headroom: umem.head_room as _,

--- a/src/umem.rs
+++ b/src/umem.rs
@@ -88,7 +88,7 @@ impl Umem {
         Ok(Self {
             mmap,
             available,
-            frame_size: cfg.frame_size as usize - libc::xdp::XDP_PACKET_HEADROOM,
+            frame_size: cfg.frame_size as usize - libc::xdp::XDP_PACKET_HEADROOM as usize,
             frame_mask: !(cfg.frame_size as u64 - 1),
             head_room: cfg.head_room as _,
             options: if cfg.tx_metadata {

--- a/src/umem.rs
+++ b/src/umem.rs
@@ -214,29 +214,8 @@ impl Umem {
     }
 
     #[inline]
-    pub(crate) fn popper(&mut self) -> UmemPopper<'_> {
-        UmemPopper {
-            available: &mut self.available,
-        }
-    }
-}
-
-pub(crate) struct UmemPopper<'umem> {
-    available: &'umem mut VecDeque<u64>,
-}
-
-impl UmemPopper<'_> {
-    #[inline]
-    pub(crate) fn len(&self) -> usize {
-        self.available.len()
-    }
-
-    #[inline]
-    pub(crate) fn pop(&mut self) -> u64 {
-        let Some(addr) = self.available.pop_front() else {
-            unreachable!()
-        };
-        addr
+    pub(crate) fn available(&mut self) -> &mut VecDeque<u64> {
+        &mut self.available
     }
 }
 


### PR DESCRIPTION
* All `unsafe` usage now has a (sometimes minimal...) `SAFETY:` comment for my own sanity
* Changed some libc definitions to just use u8 instead of i8 (c_char) since they were annoying to deal with, cleaning up parts of the nic code
* Fixed undefined behavior in the netlink code that was doing the same unaligned pointer casting as the old packet code
* Simplified `Packet` by keeping it simple and removing the `&'static mut [u8]` and replacing it with a *,usize pair instead as most of the code is directly interacting with the pointer anways. Also fixed a bug where the capacity was incorrectly including the `XDP_PACKET_HEADROOM`
* Moved `HeapSlab` into a `slab` module, and added a new `Slab` trait and a new implementation, `StackSlab` which is a simple fixed size ring buffer
* Lots of internal cleanup